### PR TITLE
Analyze background process logs for errors

### DIFF
--- a/app/research/production_deep_research_agent.ts
+++ b/app/research/production_deep_research_agent.ts
@@ -617,7 +617,8 @@ Your goal is to produce research that meets academic and professional standards 
       // Filter scraped content by quality
       const quality_content = scraped_results.filter(
         (content) =>
-          content.quality_score >= 0.5 && content.metadata.word_count >= 200
+          content.quality_metrics?.credibility_score >= 0.5 && 
+          content.metadata?.word_count >= 200
       );
 
       // Adapt scraped content to expected schema with all required properties
@@ -625,10 +626,11 @@ Your goal is to produce research that meets academic and professional standards 
         ...content,
         clean_text: content.content,
         markdown: content.content,
+        quality_score: content.quality_metrics?.credibility_score || 0.5,
         quality_metrics: {
-          credibility_score: content.quality_score,
-          authority_indicators: [],
-          readability_score: content.quality_score,
+          credibility_score: content.quality_metrics?.credibility_score || 0.5,
+          authority_indicators: content.quality_metrics?.authority_indicators || [],
+          readability_score: content.quality_metrics?.readability_score || 0.5,
         },
         scrape_duration: 0,
         extracted_data: {

--- a/app/research/real_synthesizer.ts
+++ b/app/research/real_synthesizer.ts
@@ -547,10 +547,7 @@ Return your analysis as a structured list of claims with:
           "length:",
           messages?.length
         );
-        const response = await this.llm.ask(messages, {
-          temperature: 0.2,
-          max_tokens: 2000,
-        });
+        const response = await this.llm.ask(messages, undefined, true, 0.2);
 
         if (response) {
           const insight = await this.parse_validation_response(


### PR DESCRIPTION
Correctly access nested scraped content quality scores and fix LLM `ask` method parameter order to resolve "0 scraped sources" and "messages is not iterable" errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bc3696d-d9ad-444d-b3c5-f2fbafe29a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bc3696d-d9ad-444d-b3c5-f2fbafe29a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes scraped content filtering/mapping to use `quality_metrics.credibility_score` and updates `llm.ask` call signature to prevent runtime errors.
> 
> - **Research Agent (scraping)**:
>   - Filter uses `content.quality_metrics?.credibility_score` and `content.metadata?.word_count` in `app/research/production_deep_research_agent.ts`.
>   - Adapted output maps `quality_score` from `quality_metrics.credibility_score` and populates `quality_metrics` fields with safe defaults.
> - **Synthesis (LLM invocation)**:
>   - Update `llm.ask` call in `app/research/real_synthesizer.ts` to new signature `ask(messages, undefined, true, 0.2)` (replacing options object).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed97f67fd6b1f3e1e8044e73dd0681172a01b189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->